### PR TITLE
Update SPD rosters, improve utility scripts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,8 @@
-DB_USERNAME=the username the database will use (default is "postgres", I think it has to be "postgres" but unsure)
-DB_PASSWORD=password the database will use. Be sure to generate a good, high entropy password here.
-DB_IMAGE_TAG=default will likely be "latest" but can also be any tag available for the image hosted at https://hub.docker.com/repository/docker/sdsa/spd-lookup-db
-API_IMAGE_TAG=default will likely be "latest" but can also be any tag available for the image hosted at https://hub.docker.com/repository/docker/sdsa/spd-lookup-api
+# The username the database will use (default is "postgres", I think it has to be "postgres" but unsure)
+DB_USERNAME=postgres
+# Password the database will use. Be sure to generate a good, high entropy password here.
+DB_PASSWORD=postgres
+# Default will likely be "latest" but can also be any tag available for the image hosted at https://hub.docker.com/repository/docker/sdsa/spd-lookup-db
+DB_IMAGE_TAG=latest
+# Default will likely be "latest" but can also be any tag available for the image hosted at https://hub.docker.com/repository/docker/sdsa/spd-lookup-api
+API_IMAGE_TAG=latest

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ workspace.*
 db/db_logs/
 
 act-secrets
+
+*.swp

--- a/justfile
+++ b/justfile
@@ -10,12 +10,16 @@ DC := "docker-compose " + COMPOSE_FILE
 default:
   @just --list --unsorted
 
+# Create the .env file from the template
+dotenv:
+    @([ ! -f .env ] && cp .env.example .env) || true
+
 # Build the containers
-build:
+build: dotenv
 	{{ DC }} build
 
 # Spin up all (or one) service
-up service="":
+up service="": dotenv
 	{{ DC }} up -d {{ service }}
 
 # Tear down containers

--- a/scripts/add_to_current_roster.py
+++ b/scripts/add_to_current_roster.py
@@ -4,14 +4,32 @@ import click
 
 from pandas import DataFrame
 
-DEFAULT_HISTORICAL = Path(__file__).parents[1] / "seed" / "Seattle-WA-Police-Department_Historical.csv"
-COLUMNS = ['badge', 'full_name', 'title', 'unit', 'unit_description', 'first_name',
-       'middle_name', 'last_name', 'date']
+DEFAULT_HISTORICAL = (
+    Path(__file__).parents[1] / "seed" / "Seattle-WA-Police-Department_Historical.csv"
+)
+COLUMNS = [
+    "badge",
+    "full_name",
+    "title",
+    "unit",
+    "unit_description",
+    "first_name",
+    "middle_name",
+    "last_name",
+    "date",
+]
 
 
 @click.command()
-@click.argument('input_csvs', nargs=-1)
-@click.option('-h', '--historical-csv', default=str(DEFAULT_HISTORICAL), type=str, prompt=True, help='Path to the historical CSV. This file will be replaced with the updated version')
+@click.argument("input_csvs", nargs=-1)
+@click.option(
+    "-h",
+    "--historical-csv",
+    default=str(DEFAULT_HISTORICAL),
+    type=str,
+    prompt=True,
+    help="Path to the historical CSV. This file will be replaced with the updated version",
+)
 def main(input_csvs, historical_csv):
     # Read in the historical CSV
     df = pd.read_csv(historical_csv)

--- a/scripts/add_to_current_roster.py
+++ b/scripts/add_to_current_roster.py
@@ -1,0 +1,31 @@
+from pathlib import Path
+import pandas as pd
+import click
+
+from pandas import DataFrame
+
+DEFAULT_HISTORICAL = Path(__file__).parents[1] / "seed" / "Seattle-WA-Police-Department_Historical.csv"
+COLUMNS = ['badge', 'full_name', 'title', 'unit', 'unit_description', 'first_name',
+       'middle_name', 'last_name', 'date']
+
+
+@click.command()
+@click.argument('input_csvs', nargs=-1)
+@click.option('-h', '--historical-csv', default=str(DEFAULT_HISTORICAL), type=str, prompt=True, help='Path to the historical CSV. This file will be replaced with the updated version')
+def main(input_csvs, historical_csv):
+    # Read in the historical CSV
+    df = pd.read_csv(historical_csv)
+
+    for input_csv in input_csvs:
+        print(f"Adding {input_csv}")
+        # Read the CSV, gathering only a subset of the columns
+        xdf = pd.read_csv(input_csv, usecols=COLUMNS)
+        # Append the dataframe
+        df = df.append(xdf, ignore_index=True)
+
+    # Write out resulting DataFrame to CSV path specified
+    df.to_csv(historical_csv, index=False)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/prep-spd-roster.py
+++ b/scripts/prep-spd-roster.py
@@ -61,7 +61,7 @@ def main(date, in_csv, out_csv):
     # Sometimes there some weird "K_Jr" bullshit for the middle name we have to deal with
     # This creates a dataframe with 3 new columns: 1) middle bits, 2) suffix, 3) blank because of the split
     middle_bits = not_last_names[1].str.split(
-        r"((?:Jr|I[iI]|I[iI][iI]|I[vV])\.?$)", expand=True
+        r"(?i)((?:Jr|II|III|IV)\.?$)", expand=True
     )
     # Make all suffixes upper, except for "Jr", and trim periods
     df["suffix"] = middle_bits[1].str.strip(".").str.upper().str.replace("JR", "Jr")

--- a/scripts/prep-spd-roster.py
+++ b/scripts/prep-spd-roster.py
@@ -1,7 +1,7 @@
 import pandas as pd
 import click
 
-from pandas.core.frame import DataFrame
+from pandas import DataFrame
 
 
 @click.command()
@@ -20,29 +20,34 @@ def main(date, in_csv, out_csv):
         'Unit': 'unit',
         'Unit_Description': 'unit_description'
     }
-    df.rename(columns=column_names, inplace=True)
+    df = df.rename(columns=column_names)
 
     # Strip out unwanted whitespace from any string fields in the DataFrame
     df = df.applymap(lambda x: x.strip() if isinstance(x, str) else x)
 
     # Split the names out
-    df['first_name'] = df["full_name"].str.split(",").str[1].str.strip().str.split(" ").str[0]
-    df['middle_name'] = df.apply(lambda x: middle_name(x), axis=1)
-    df['last_name'] = df["full_name"].str.split(",").str[0]
+    names = df["full_name"].str.split(",", expand=True)
+    # Last name is predictably before the comma, so we can set it outright
+    df["last_name"] = names[0]
+    # Assumption: first name will always be the text before the first space
+    # We can set first name to be the first split based off that
+    not_last_names = names[1].str.split(n=1, expand=True)
+    df["first_name"] = not_last_names[0]
+    # Next we have to split apart the middle name and the suffix
+    # Sometimes there some weird "K_Jr" bullshit for the middle name we have to deal with
+    # This creates a dataframe with 3 new columns: 1) middle bits, 2) suffix, 3) blank because of the split
+    middle_bits = not_last_names[1].str.split(r"((?:Jr|I[iI]|I[iI][iI]|I[vV])\.?$)", expand=True)
+    # Make all suffixes upper, except for "Jr", and trim periods
+    df["suffix"] = middle_bits[1].str.strip(".").str.upper().str.replace("JR", "Jr")
+    # The first part of the middle bits is now the middle name
+    # (but we also have to remove the "_" or "." in some cases)
+    df["middle_name"] = middle_bits[0].str.strip("_").str.strip(".")
 
     # Add date column to DataFrame
     df['date'] = date
 
     # Write out resulting DataFrame to CSV path specified
     df.to_csv(out_csv, index=False)
-
-
-def middle_name(df: DataFrame):
-    name_list = df['full_name'].split(',')[1].split(' ')
-    if len(name_list) > 2:
-        return ' '.join(name_list[2:])
-    else:
-        return ''
 
 
 if __name__ == "__main__":

--- a/scripts/prep-spd-roster.py
+++ b/scripts/prep-spd-roster.py
@@ -16,9 +16,12 @@ def main(date, in_csv, out_csv):
     column_names = {
         'Name': 'full_name',
         'Badge_Num': 'badge',
+        "Serial": 'badge',
         'Title_Description': 'title',
+        'Title Description': 'title',
         'Unit': 'unit',
-        'Unit_Description': 'unit_description'
+        'Unit Description': 'unit_description',
+        'Unit_Description': 'unit_description',
     }
     df = df.rename(columns=column_names)
 

--- a/scripts/prep-spd-roster.py
+++ b/scripts/prep-spd-roster.py
@@ -5,23 +5,44 @@ from pandas import DataFrame
 
 
 @click.command()
-@click.option('-d', '--date', required=True, type=str, prompt=True, help='The date of the roster in the format YYYY-MM-DD.')
-@click.option('-i', '--in-csv', required=True, type=str, prompt=True, help='Path to the source file. Can be relative to current directory.')
-@click.option('-o', '--out-csv', required=True, type=str, prompt=True, help='Path to save the resulting CSV in. Can be relative to current directory.')
+@click.option(
+    "-d",
+    "--date",
+    required=True,
+    type=str,
+    prompt=True,
+    help="The date of the roster in the format YYYY-MM-DD.",
+)
+@click.option(
+    "-i",
+    "--in-csv",
+    required=True,
+    type=str,
+    prompt=True,
+    help="Path to the source file. Can be relative to current directory.",
+)
+@click.option(
+    "-o",
+    "--out-csv",
+    required=True,
+    type=str,
+    prompt=True,
+    help="Path to save the resulting CSV in. Can be relative to current directory.",
+)
 def main(date, in_csv, out_csv):
     # Import CSV passed to script
     df = pd.read_csv(in_csv)
 
     # Rename columns to better formatting
     column_names = {
-        'Name': 'full_name',
-        'Badge_Num': 'badge',
-        "Serial": 'badge',
-        'Title_Description': 'title',
-        'Title Description': 'title',
-        'Unit': 'unit',
-        'Unit Description': 'unit_description',
-        'Unit_Description': 'unit_description',
+        "Name": "full_name",
+        "Badge_Num": "badge",
+        "Serial": "badge",
+        "Title_Description": "title",
+        "Title Description": "title",
+        "Unit": "unit",
+        "Unit Description": "unit_description",
+        "Unit_Description": "unit_description",
     }
     df = df.rename(columns=column_names)
 
@@ -39,7 +60,9 @@ def main(date, in_csv, out_csv):
     # Next we have to split apart the middle name and the suffix
     # Sometimes there some weird "K_Jr" bullshit for the middle name we have to deal with
     # This creates a dataframe with 3 new columns: 1) middle bits, 2) suffix, 3) blank because of the split
-    middle_bits = not_last_names[1].str.split(r"((?:Jr|I[iI]|I[iI][iI]|I[vV])\.?$)", expand=True)
+    middle_bits = not_last_names[1].str.split(
+        r"((?:Jr|I[iI]|I[iI][iI]|I[vV])\.?$)", expand=True
+    )
     # Make all suffixes upper, except for "Jr", and trim periods
     df["suffix"] = middle_bits[1].str.strip(".").str.upper().str.replace("JR", "Jr")
     # The first part of the middle bits is now the middle name
@@ -47,7 +70,7 @@ def main(date, in_csv, out_csv):
     df["middle_name"] = middle_bits[0].str.strip("_").str.strip(".")
 
     # Add date column to DataFrame
-    df['date'] = date
+    df["date"] = date
 
     # Write out resulting DataFrame to CSV path specified
     df.to_csv(out_csv, index=False)


### PR DESCRIPTION
**DO NOT BE ALARMED BY THE NUMBER OF LINES CHANGED** (most of those are from the new data)

This PR accomplishes a few things:
- Improve the "full name" splitting heuristic using regex splitting. This has been quite successful and has only resulted in one incorrectly parsed because the SPD data is awful and they have `_J` instead of `_Jr` because the name is so long. I'm too lazy to fix it and it's only one name, close enough.
    - It's worth noting that this now produces a CSV file with a `suffix` column. Our current data model doesn't include this field, which is fine. It's necessary for OpenOversight though, so it seemed prudent to keep that logic _somewhere_ for when I eventually add these rosters into OO.
- Added a script which will take a number of prepped CSVs and append them to the historical file. Small script but mostly just a convenience/provenance thing.
- gitignore vim swap files.
- Add justfile recipe for creating the .env file automatically if it doesn't exist. This is useful for fresh clones of the repository.
- Update historical roster with July 1,31 & Oct 26th.
