### PR TITLE
Run the build context inside the actual service folder

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,7 +33,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           push: true
-          file: ${{ matrix.service }}/Dockerfile
+          context: ./${{ matrix.service }}
           tags: |
             ghcr.io/${{ env.image_name }}-${{ matrix.service }}:${{ github.sha }}
             ghcr.io/${{ env.image_name }}-${{ matrix.service }}:${{ github.ref_name }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,6 +33,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           push: true
+          context: ${{ matrix.service }}
           tags: |
             ghcr.io/${{ env.image_name }}-${{ matrix.service }}:${{ github.sha }}
             ghcr.io/${{ env.image_name }}-${{ matrix.service }}:${{ github.ref_name }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,7 +33,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           push: true
-          context: ./${{ matrix.service }}
+          file: ${{ matrix.service }}/Dockerfile
           tags: |
             ghcr.io/${{ env.image_name }}-${{ matrix.service }}:${{ github.sha }}
             ghcr.io/${{ env.image_name }}-${{ matrix.service }}:${{ github.ref_name }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,7 +33,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           push: true
-          context: ${{ matrix.service }}
+          file: ${{ matrix.service }}/Dockerfile
           tags: |
             ghcr.io/${{ env.image_name }}-${{ matrix.service }}:${{ github.sha }}
             ghcr.io/${{ env.image_name }}-${{ matrix.service }}:${{ github.ref_name }}

--- a/db/Dockerfile
+++ b/db/Dockerfile
@@ -1,9 +1,9 @@
 FROM postgres:alpine
 
-COPY *.conf /data/
+COPY ./db/*.conf /data/
 
-COPY sql/* /docker-entrypoint-initdb.d/
+COPY ./db/sql/* /docker-entrypoint-initdb.d/
 
-COPY seed/* /seed/
+COPY ./db/seed/* /seed/
 
 EXPOSE 5432

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,8 +1,10 @@
 version: '3'
 services:
   db:
-    build: ./db
+    build:
+      context: .
+      dockerfile: ./db/Dockerfile
   api:
     build:
-      context: ./
+      context: .
       dockerfile: ./api/Dockerfile


### PR DESCRIPTION
Small fixup for #53, we have two services so we need to define two different docker contexts.
